### PR TITLE
Gjør det lettere å søke på statistikk

### DIFF
--- a/barnehage/kgcontroller.py
+++ b/barnehage/kgcontroller.py
@@ -270,7 +270,8 @@ def hent_barnehage_statistikk(kommune: str) -> DataFrame:
         data[DATA_KOLONNER] = data[DATA_KOLONNER].map(lambda verdi: np.nan if verdi > 100 else verdi)
         data[DATA_KOLONNER] = data[DATA_KOLONNER].map(lambda verdi: round(verdi, 2))
         data = data.drop(data.index[730:])
-        data = data.dropna()
+        data["Kommune"] = data["Kommune"].str.split(" ", n=1).str[1]
+        data["Kommune"] = data["Kommune"].str.replace(r"\s*\(.*\)", "", regex=True)
 
         return data
     

--- a/barnehage/templates/statistikk.html
+++ b/barnehage/templates/statistikk.html
@@ -4,7 +4,13 @@
 
 	<form method="post">
 		<label for="kommune">Navn på Kommune:</label>
-		<input type="text" id="kommune" name="kommune" required />
+		<input
+			type="text"
+			id="kommune"
+			name="kommune"
+			required
+			placeholder="Kristiansand"
+		/>
 		<button type="submit">Søk</button>
 	</form>
 


### PR DESCRIPTION
Tidligere kode gjorde ingen rensing på Kommune kolonnen i SSB sin datasett. Denne koden fjerner talla på starten slik at brukeren trenger bare å skrive navnet på kommunen. I tillegg blir det ikke fjernet rader med tomme kolonner.